### PR TITLE
feat(rule): do not check for the complete method to be called since i…

### DIFF
--- a/rules/angularRxjsTakeuntilBeforeSubscribeRule.ts
+++ b/rules/angularRxjsTakeuntilBeforeSubscribeRule.ts
@@ -415,7 +415,7 @@ export class Rule extends Lint.Rules.TypedRule {
   }
 
   /**
-   * Checks whether the class implements an ngOnDestroy method and invokes .next() and .complete() on the destroy subjects
+   * Checks whether the class implements an ngOnDestroy method and invokes .next() on the destroy subjects
    */
   private checkNgOnDestroy(
     sourceFile: ts.SourceFile,
@@ -428,7 +428,7 @@ export class Rule extends Lint.Rules.TypedRule {
     );
 
     // check whether the ngOnDestroy method is implemented
-    // and contains invocations of .next() and .complete() on all destroy subjects used
+    // and contains invocations of .next() on all destroy subjects used
     if (ngOnDestroyMethod) {
       failures.push(
         ...this.checkDestroySubjectMethodInvocation(
@@ -436,14 +436,6 @@ export class Rule extends Lint.Rules.TypedRule {
           ngOnDestroyMethod,
             destroySubjectNameUsed,
           "next"
-        )
-      );
-      failures.push(
-        ...this.checkDestroySubjectMethodInvocation(
-          sourceFile,
-          ngOnDestroyMethod,
-            destroySubjectNameUsed,
-          "complete"
         )
       );
     } else {

--- a/test/rules/angular-rxjs-takeuntil-before-subscribe/component/fixture.ts.lint
+++ b/test/rules/angular-rxjs-takeuntil-before-subscribe/component/fixture.ts.lint
@@ -78,10 +78,8 @@ class MyComponent implements OnDestroy {
 
     ngOnDestroy() {
     ~~~~~~~~~~~            [angular-rxjs-takeuntil-before-subscribe-subscribe-next-missing]
-    ~~~~~~~~~~~            [angular-rxjs-takeuntil-before-subscribe-subscribe-complete-missing]
       // this._destroy$.next() is missing
       this.destroy$.next();
-      this.destroy$.complete();
     }
 }
 
@@ -126,7 +124,6 @@ class MyComponent implements SomeInterface, OnDestroy {
 
     ngOnDestroy() {
       this.destroy$.next();
-      this.destroy$.complete();
     }
 }
 
@@ -140,7 +137,6 @@ class MySuperAbstractComponent2 {
 
     ngOnDestroy() {
       this.destroy$.next();
-      this.destroy$.complete();
     }
 }
 

--- a/test/rules/angular-rxjs-takeuntil-before-subscribe/directive/fixture.ts.lint
+++ b/test/rules/angular-rxjs-takeuntil-before-subscribe/directive/fixture.ts.lint
@@ -73,7 +73,6 @@ class MyDirective implements OnDestroy {
 
     ngOnDestroy() {
     ~~~~~~~~~~~            [angular-rxjs-takeuntil-before-subscribe-subscribe-next-missing]
-    ~~~~~~~~~~~            [angular-rxjs-takeuntil-before-subscribe-subscribe-complete-missing]
       // this._destroy$.next() is missing
       this.destroy$.next();
       this.destroy$.complete();


### PR DESCRIPTION
On Twitter people pointed out that we don't need to call the complete method of the destroy$. 

I just had a look into the RxJS source code and saw that take until doesn't only unsubscribe from the source but also from the notifier.

```class TakeUntilOperator<T> implements Operator<T, T> {
  constructor(private notifier: Observable<any>) {
  }

  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
    const takeUntilSubscriber = new TakeUntilSubscriber(subscriber);
    const notifierSubscription = subscribeToResult(takeUntilSubscriber, this.notifier);
    if (notifierSubscription && !takeUntilSubscriber.seenValue) {
      takeUntilSubscriber.add(notifierSubscription);
      return source.subscribe(takeUntilSubscriber);
    }
    return takeUntilSubscriber;
  }
}
```

Not only the source but also the notifier gets unsubscribed. So, therefore, we don't need to call complete. @macjohnny, @tomastrajan  what do you think?